### PR TITLE
Enable scrollbars on haaretz.co.il

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Updates--
 
+2018-07-08 v1.3.2: Fixed Haaretz (haaretz.co.il)
 2018-07-07 v1.3.1: Added Business Insider (businessinsider.com)
 2018-07-04 v1.3.0: Added The Denver Post (denverpost.com, note: need to turn off uBlock for this site), added Hacked (hacked.com)
 2018-06-20 v1.2.10: Added The Business Journals (bizjournals.com)

--- a/contentScript.js
+++ b/contentScript.js
@@ -20,3 +20,15 @@ if (window.location.href.indexOf("bizjournals.com") !== -1) {
     paywall[0].parentNode.removeChild(paywall[0]);
   }
 }
+
+if (location.hostname.endsWith('haaretz.co.il')) {
+  const html = document.getElementsByTagName('html');
+  if (html && html.length > 0) {
+    html[0].style['overflow-y'] = 'auto';
+  }
+
+  const msg = document.getElementById('article-wrapper');
+  if (msg) {
+    msg.style['display'] = 'none';
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["*://*.bizjournals.com/*", "*://*.businessinsider.com/*"],
+			"matches": ["*://*.bizjournals.com/*", "*://*.businessinsider.com/*", "*://*.haaretz.co.il/*"],
 			"js": ["contentScript.js"]
 		}
 	],
@@ -43,5 +43,5 @@
 		"webRequest",
 		"webRequestBlocking"
 	],
-	"version": "1.3.1"
+	"version": "1.3.2"
 }

--- a/popup.html
+++ b/popup.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<div style="width:220px;">Bypass Paywalls v1.3.1 by Adam
+<div style="width:220px;">Bypass Paywalls v1.3.2 by Adam
 <a href="options.html">Options</a></div>
 </body>
 </html>


### PR DESCRIPTION
This enables the scrollbars on bypassed haaretz.co.il pages (such as https://www.haaretz.co.il/gallery/music/.premium-1.6246607).