### PR TITLE
make disable by regex active only on enabled sites

### DIFF
--- a/background.js
+++ b/background.js
@@ -171,10 +171,6 @@ browser.runtime.onInstalled.addListener(function (details) {
 
 
 browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
-  if (blockedRegexes.some(function(regex) { return regex.test(details.url); })) {
-    return { cancel: true };
-  }
-
   var isEnabled = enabledSites.some(function(enabledSite) {
 
     var useSite = details.url.indexOf("." + enabledSite) !== -1;
@@ -189,6 +185,10 @@ browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
 
   if (!isEnabled) {
     return;
+  }
+
+  if (blockedRegexes.some(function(regex) { return regex.test(details.url); })) {
+    return { cancel: true };
   }
 
   var requestHeaders = details.requestHeaders;


### PR DESCRIPTION
this fixes haaretz.co.il for registered users (the blocked regex activates the paywall for them, see pull request #83 )