### PR TITLE
Fix repubblica.it after page reload

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -35,9 +35,9 @@ if (window.location.href.indexOf("bizjournals.com") !== -1) {
   }
 
   if (location.href.includes("/ws/detail/")) {
-    const paywall = document.getElementsByClassName('paywall');
-    if (paywall && paywall.length > 0) {
-      paywall[0].toggleAttribute('amp-access-hide');
+    const paywall = document.querySelector('.paywall[amp-access-hide]');
+    if (paywall) {
+      paywall.removeAttribute('amp-access-hide');
     }
   }
 }


### PR DESCRIPTION
This PR fixes [the previous one](https://github.com/iamadamdev/bypass-paywalls-firefox/pull/89) as I noticed that the page triggers a _ping_ to an external service and keeps toggling the hidden div with the real content.