### PR TITLE
Add Newstatesman to no-javascript list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+web-ext-artifacts

--- a/background.js
+++ b/background.js
@@ -233,10 +233,10 @@ chrome.webRequest.onBeforeRequest.addListener(function(details) {
   if (!isSiteEnabled(details) || details.url.indexOf("mod=rsswn") !== -1) {
     return;
   }
-  return {cancel: true}; 
+  return {cancel: true};
   },
   {
-    urls: ["*://*.theglobeandmail.com/*", "*://*.economist.com/*", "*://*.thestar.com/*"],
+    urls: ["*://*.theglobeandmail.com/*", "*://*.economist.com/*", "*://*.thestar.com/*", "*://*.newstatesman.com/*"],
     types: ["script"]
   },
   ["blocking"]
@@ -295,7 +295,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
 
   // override User-Agent to use Googlebot
   var useGoogleBot = use_google_bot.filter(function(item) {
-    return typeof item == 'string' && details.url.indexOf(item) > -1;            
+    return typeof item == 'string' && details.url.indexOf(item) > -1;
   }).length > 0;
 
   if (useGoogleBot) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -69,7 +69,7 @@ if (window.location.href.indexOf("bizjournals.com") !== -1) {
   }
 } else if (window.location.href.indexOf("wsj.com") !== -1) {
   if (location.href.includes('/articles/')) {
-    setTimeout(function() { 
+    setTimeout(function() {
       document.querySelector('.close-btn').click();
     }, 2000);
   }
@@ -86,6 +86,6 @@ if (window.location.href.indexOf("bizjournals.com") !== -1) {
 
         document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
       }
-    }, 300); // Delay (in milliseconds) 
+    }, 300); // Delay (in milliseconds)
   }
 }

--- a/options.js
+++ b/options.js
@@ -33,7 +33,7 @@ var defaultSites = {
   'MIT Technology Review': 'technologyreview.com',
   'Mountain View Voice': 'mv-voice.com',
   'National Post': 'nationalpost.com',
-  'New Statesman': 'newstatesman.com',
+  'New Statesman (javascript disabled)': 'newstatesman.com',
   'New York Magazine': 'nymag.com',
   'New Zealand Herald': 'nzherald.co.nz',
   'Nikkei Asian Review': 'asia.nikkei.com',


### PR DESCRIPTION
- Add `.gitignore` for web-ext-artifacts
- Remove trailing whitespace

Fixes Newstatesman currently showing a nag-screen.

Before:

![image](https://user-images.githubusercontent.com/458214/65374290-60275780-dc56-11e9-9d47-2d03705bacb4.png)

After:

![Screen Shot 2019-09-21 at 10 01 34-fullpage](https://user-images.githubusercontent.com/458214/65374357-1e4ae100-dc57-11e9-9765-7d3ac7d3720d.jpg)
