### PR TITLE
Prevent issues with simmilar hostnames (Firefox)

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,16 +1,16 @@
 window.localStorage.clear();
 
-
 const getHostName = _ => {
-	let URL = location.hostname;
+	let url = location.hostname;
 	if (location.hostname.startsWith('www.')) {
-		return URL.replace('www.', '');
+		return url.replace('www.', '');
 	}
 
-	return URL;
+	return url;
 };
 
 const urlMatches = (url) => {
+
 	return getHostName() === url;
 };
 
@@ -38,11 +38,9 @@ if (urlMatches('businessinsider.com')) {
 	while (paywall.length > 0) {
 		paywall[0].parentNode.removeChild(paywall[0]);
 	}
-} else {
-	console.log('not busines insider', hostName)
 }
 
-if (getHostName() === 'haaretz.co.il') {
+if (urlMatches('haaretz.co.il')) {
 	const html = document.getElementsByTagName('html');
 	if (html && html.length > 0) {
 		html[0].style['overflow-y'] = 'auto';
@@ -53,7 +51,7 @@ if (getHostName() === 'haaretz.co.il') {
 	}
 }
 
-if (getHostName() === "nzherald.co.nz") !== -1) {
+if (urlMatches('nzherald.co.nz')) {
 	const paywall = document.getElementById(
 		"article-content"
 	);
@@ -78,7 +76,7 @@ if (getHostName() === "nzherald.co.nz") !== -1) {
 	}
 }
 
-if (location.hostname.endsWith('rep.repubblica.it')) {
+if (urlMatches('rep.repubblica.it')) {
 	if (location.href.includes("/pwa/")) {
 		location.href = location.href.replace("/pwa/", "/ws/detail/");
 	}
@@ -95,7 +93,7 @@ if (location.hostname.endsWith('rep.repubblica.it')) {
 	}
 }
 
-if (window.location.href.indexOf("wsj.com") !== -1) {
+if (urlMatches("wsj.com")) {
 	if (location.href.includes('/articles/')) {
 		setTimeout(function () {
 			document.querySelector('.close-btn').click();
@@ -103,7 +101,7 @@ if (window.location.href.indexOf("wsj.com") !== -1) {
 	}
 }
 
-if (window.location.href.indexOf("washingtonpost.com") !== -1) {
+if (urlMatches('washingtonpost.com')) {
 	if (location.href.includes('/gdpr-consent/')) {
 		document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,91 +1,121 @@
 window.localStorage.clear();
-if (window.location.href.indexOf("bizjournals.com") !== -1) {
-  const hiddenStory = document.getElementsByClassName(
-    "js-pre-chunks__story-body"
-  );
-  if (hiddenStory && hiddenStory.length>0) {
-    hiddenStory[0].style.display = "block";
-  }
 
-  const payWallMessage = document.getElementsByClassName(
-    "chunk chunk--flex@lg chunk--paywall"
-  );
-  if (payWallMessage && payWallMessage.length>0 ) {
-    payWallMessage[0].style.display = "none";
-  }
-} else if (window.location.href.indexOf("businessinsider.com") !== -1) {
-  const paywall = document.getElementsByClassName(
-    "tp-modal"
-  );
-  while (paywall.length > 0) {
-    paywall[0].parentNode.removeChild(paywall[0]);
-  }
-} else if (location.hostname.endsWith('haaretz.co.il')) {
-  const html = document.getElementsByTagName('html');
-  if (html && html.length > 0) {
-    html[0].style['overflow-y'] = 'auto';
-  }
-   const msg = document.getElementById('article-wrapper');
-  if (msg) {
-    msg.style['display'] = 'none';
-  }
-} else if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
-  const paywall = document.getElementById(
-    "article-content"
-  );
-  if (paywall) {
-    paywall.classList.remove('premium-content');
-    paywall.classList.add('full-content');
-    var paras = paywall.querySelectorAll("p, span, h2, div");
-    var delClass = "";
-    for (var i = 0; i < paras.length; i++) {
-      if (paras[i].nodeName == 'P' || paras[i].nodeName == 'SPAN') {
-        paras[i].classList.remove("ellipsis");
-        if (delClass == "" && paras[i].className != "") {
-          delClass = paras[i].className;
-        } else {
-            if (delClass != "") {
-              paras[i].classList.remove(delClass);
-            }
-        }
-      }
-      paras[i].removeAttribute('style');
-    }
-  }
-} else if (location.hostname.endsWith('rep.repubblica.it')) {
-  if (location.href.includes("/pwa/")) {
-    location.href = location.href.replace("/pwa/", "/ws/detail/");
-  }
 
-  if (location.href.includes("/ws/detail/")) {
-    const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
-    if (paywall) {
-      paywall.removeAttribute('subscriptions-section');
-      const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
-      if (preview) {
-        preview.remove();
-      }
-    }
-  }
-} else if (window.location.href.indexOf("wsj.com") !== -1) {
-  if (location.href.includes('/articles/')) {
-    setTimeout(function() {
-      document.querySelector('.close-btn').click();
-    }, 2000);
-  }
-} else if (window.location.href.indexOf("washingtonpost.com") !== -1) {
-  if (location.href.includes('/gdpr-consent/')) {
-    document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
+const getHostName = _ => {
+	let URL = location.hostname;
+	if (location.hostname.startsWith('www.')) {
+		return URL.replace('www.', '');
+	}
 
-    setTimeout(function (){
+	return URL;
+};
 
-      const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
-      if (gdprcheckbox) {
-        gdprcheckbox.checked = true;
-        gdprcheckbox.dispatchEvent(new Event('change'));
+const urlMatches = (url) => {
+	return getHostName() === url;
+};
 
-        document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
-      }
-    }, 300); // Delay (in milliseconds)
-  }
+
+if (urlMatches('bizjournals.com')) {
+	const hiddenStory = document.getElementsByClassName(
+		"js-pre-chunks__story-body"
+	);
+	if (hiddenStory && hiddenStory.length > 0) {
+		hiddenStory[0].style.display = "block";
+	}
+
+	const payWallMessage = document.getElementsByClassName(
+		"chunk chunk--flex@lg chunk--paywall"
+	);
+	if (payWallMessage && payWallMessage.length > 0) {
+		payWallMessage[0].style.display = "none";
+	}
+}
+
+if (urlMatches('businessinsider.com')) {
+	const paywall = document.getElementsByClassName(
+		"tp-modal"
+	);
+	while (paywall.length > 0) {
+		paywall[0].parentNode.removeChild(paywall[0]);
+	}
+} else {
+	console.log('not busines insider', hostName)
+}
+
+if (getHostName() === 'haaretz.co.il') {
+	const html = document.getElementsByTagName('html');
+	if (html && html.length > 0) {
+		html[0].style['overflow-y'] = 'auto';
+	}
+	const msg = document.getElementById('article-wrapper');
+	if (msg) {
+		msg.style['display'] = 'none';
+	}
+}
+
+if (getHostName() === "nzherald.co.nz") !== -1) {
+	const paywall = document.getElementById(
+		"article-content"
+	);
+	if (paywall) {
+		paywall.classList.remove('premium-content');
+		paywall.classList.add('full-content');
+		var paras = paywall.querySelectorAll("p, span, h2, div");
+		var delClass = "";
+		for (var i = 0; i < paras.length; i++) {
+			if (paras[i].nodeName == 'P' || paras[i].nodeName == 'SPAN') {
+				paras[i].classList.remove("ellipsis");
+				if (delClass == "" && paras[i].className != "") {
+					delClass = paras[i].className;
+				} else {
+					if (delClass != "") {
+						paras[i].classList.remove(delClass);
+					}
+				}
+			}
+			paras[i].removeAttribute('style');
+		}
+	}
+}
+
+if (location.hostname.endsWith('rep.repubblica.it')) {
+	if (location.href.includes("/pwa/")) {
+		location.href = location.href.replace("/pwa/", "/ws/detail/");
+	}
+
+	if (location.href.includes("/ws/detail/")) {
+		const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
+		if (paywall) {
+			paywall.removeAttribute('subscriptions-section');
+			const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
+			if (preview) {
+				preview.remove();
+			}
+		}
+	}
+}
+
+if (window.location.href.indexOf("wsj.com") !== -1) {
+	if (location.href.includes('/articles/')) {
+		setTimeout(function () {
+			document.querySelector('.close-btn').click();
+		}, 2000);
+	}
+}
+
+if (window.location.href.indexOf("washingtonpost.com") !== -1) {
+	if (location.href.includes('/gdpr-consent/')) {
+		document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
+
+		setTimeout(function () {
+
+			const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
+			if (gdprcheckbox) {
+				gdprcheckbox.checked = true;
+				gdprcheckbox.dispatchEvent(new Event('change'));
+
+				document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
+			}
+		}, 300); // Delay (in milliseconds)
+	}
 }


### PR DESCRIPTION
This PR is to prevent issues with similar names.
For example, if we had names like `website.com` and `websitealpha.com` both pages DOM altering rules would be applied. 

Here we fix that and make hostname checking easier.