### PR TITLE
Fix NYTimes subscription form/Caixin Global & typo Bloomberg Quint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [Baltimore Sun](https://www.baltimoresun.com)\
 [Barron's](https://www.barrons.com)\
 [Bloomberg](https://www.bloomberg.com)\
-[Bloomberg Quint]('https://www.bloombergquint.com)\
+[Bloomberg Quint](https://www.bloombergquint.com)\
 [Business Insider](https://www.businessinsider.com)\
 [Caixin](https://www.caixinglobal.com)\
 [Chemical & Engineering News](https://cen.acs.org)\

--- a/contentScript.js
+++ b/contentScript.js
@@ -161,10 +161,19 @@ if (window.location.href.indexOf('lemonde.fr') !== -1) {
 }
 
 if (window.location.href.indexOf("nytimes.com") !== -1) {
-
     const preview_button = document.querySelector('.css-3s1ce0');
         if (preview_button)
             preview_button.click();
+}
+
+if (window.location.href.indexOf("caixinglobal.com") !== -1) {
+	const appContent = document.getElementById('appContent');
+	if (appContent) {
+		const p_hidden = document.querySelectorAll('p:not([style="display:block;"]');
+		for (var i = 0; i < p_hidden.length; i++) {
+			p_hidden[i].setAttribute('style', 'display:block;');
+		}
+	}
 }
 
 function removeDOMElement(...elements) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -160,6 +160,13 @@ if (window.location.href.indexOf('lemonde.fr') !== -1) {
     });
 }
 
+if (window.location.href.indexOf("nytimes.com") !== -1) {
+
+    const preview_button = document.querySelector('.css-3s1ce0');
+        if (preview_button)
+            preview_button.click();
+}
+
 function removeDOMElement(...elements) {
 	for (let element of elements) {
 		if (element) element.remove();

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
 		"*://*.bizjournals.com/*",
 		"*://*.bloomberg.com/*",
 		"*://*.businessinsider.com/*",
+		"*://*.caixinglobal.com/*",
 		"*://*.ed.nl/*",
 		"*://*.haaretz.co.il/*",
 		"*://*.lemonde.fr/*",		

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
 		"*://*.ed.nl/*",
 		"*://*.haaretz.co.il/*",
 		"*://*.lemonde.fr/*",		
+		"*://*.nytimes.com/*",		
 		"*://*.nzherald.co.nz/*",
 		"*://*.parool.nl/*",
 		"*://*.repubblica.it/*",


### PR DESCRIPTION
Fix NYTimes: close subscription form (@iscreamcoke)

Fix Caixin Global
Fixes issue #379 

Typo Bloomberg Quint (ReadME)