### PR TITLE
use googlebot user agent for haaretz.co.il

### DIFF
--- a/background.js
+++ b/background.js
@@ -192,6 +192,7 @@ const use_google_bot = [
 'theaustralian.com.au',
 'thetimes.co.uk',
 'wsj.com',
+'haaretz.co.il',
 ]
 
 function setDefaultOptions() {

--- a/manifest.json
+++ b/manifest.json
@@ -144,5 +144,5 @@
 	"*://*.scientificamerican.com/*",
 	"*://*.thehindu.com/*"
   ],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }


### PR DESCRIPTION
bypassing by referrer no longer works in [haaretz.co.il](https://www.haaretz.co.il/news/law/.premium-1.6980826).