### PR TITLE
apply googlebot fix to haaretz.com and themarker.com too

### DIFF
--- a/background.js
+++ b/background.js
@@ -204,6 +204,8 @@ const use_google_bot = [
 'thetimes.co.uk',
 'wsj.com',
 'haaretz.co.il',
+'haaretz.com',
+'themarker.com',
 ]
 
 function setDefaultOptions() {


### PR DESCRIPTION
apply googlebot fix to haaretz.com and themarker.com too, see issue #282 .

I couldn't find any article on [haaretz.com](https://www.haaretz.com/) that don't work with the previous version, but since they are from the same company we should expect them to apply similar methods in the near future.