### PR TITLE
Fix WSJ/Foreign Policy & add Philadelphia Inquirer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 [The New York Times](https://www.nytimes.com)\
 [The New Yorker](https://www.newyorker.com)\
 [The News-Gazette](https://www.news-gazette.com)\
+[The Philadelphia Inquirer](https://inquirer.com)\
 [The Saturday Paper](https://www.thesaturdaypaper.com.au)\
 [The Spectator](https://www.spectator.co.uk)\
 [The Seattle Times](https://www.seattletimes.com)\

--- a/background.js
+++ b/background.js
@@ -230,7 +230,8 @@ const blockedRegexes = {
 'nzherald.co.nz': /nzherald\.co\.nz\/.+\/headjs\/.+\.js/,
 'economist.com': /.+\.tinypass\.com\/.+/,
 'lrb.co.uk': /.+\.tinypass\.com\/.+/,
-'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/
+'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/,
+'foreignpolicy.com': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"

--- a/background.js
+++ b/background.js
@@ -79,6 +79,7 @@ var defaultSites = {
   'The New York Times': 'nytimes.com',
   'The New Yorker': 'newyorker.com',
   'The News-Gazette': 'news-gazette.com',
+  'The Philadelphia Inquirer': 'inquirer.com',
   'The Saturday Paper': 'thesaturdaypaper.com.au',
   'The Spectator': 'spectator.co.uk',
   'The Seattle Times': 'seattletimes.com',
@@ -231,7 +232,8 @@ const blockedRegexes = {
 'economist.com': /.+\.tinypass\.com\/.+/,
 'lrb.co.uk': /.+\.tinypass\.com\/.+/,
 'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/,
-'foreignpolicy.com': /.+\.tinypass\.com\/.+/
+'foreignpolicy.com': /.+\.tinypass\.com\/.+/,
+'inquirer.com': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"

--- a/background.js
+++ b/background.js
@@ -93,7 +93,7 @@ var defaultSites = {
   'Trouw': 'trouw.nl',
   'Vanity Fair': 'vanityfair.com',
   'Vrij Nederland': 'vn.nl',
-  'Wired': 'wired.com'
+  'Wired': 'wired.com',
 };
 
 const restrictions = {
@@ -148,6 +148,7 @@ const allow_cookies = [
 const remove_cookies = [
 'ad.nl',
 'asia.nikkei.com',
+'bloombergquint.com',
 'bostonglobe.com',
 'cen.acs.org',
 'chicagobusiness.com',
@@ -178,15 +179,12 @@ const remove_cookies = [
 'thestar.com',
 'towardsdatascience.com',
 'vn.nl',
-'washingtonpost.com',
-'wsj.com',
-'bloombergquint.com'
+'washingtonpost.com'
 ]
 
 // select specific cookie(s) to hold from remove_cookies domains
 const remove_cookies_select_hold = {
-	'washingtonpost.com': ['wp_gdpr'],
-	'wsj.com': ['wsjregion']
+	'washingtonpost.com': ['wp_gdpr']
 }
 
 // select only specific cookie(s) to drop from remove_cookies domains

--- a/manifest.json
+++ b/manifest.json
@@ -152,7 +152,8 @@
     "*://*.lrb.co.uk/*",
     "*://*.the-tls.co.uk/*",
     "*://*.harpers.org/*",
-    "*://*.nknews.org/*"
+    "*://*.nknews.org/*",
+    "*://*.inquirer.com/*"
   ],
   "version": "1.6.2"
 }

--- a/options.js
+++ b/options.js
@@ -77,6 +77,7 @@ var defaultSites = {
   'The New York Times': 'nytimes.com',
   'The New Yorker': 'newyorker.com',
   'The News-Gazette': 'news-gazette.com',
+  'The Philadelphia Inquirer': 'inquirer.com',
   'The Saturday Paper': 'thesaturdaypaper.com.au',
   'The Spectator': 'spectator.co.uk',
   'The Seattle Times': 'seattletimes.com',


### PR DESCRIPTION
Fix WSJ (reformatting)
Maintain cookies to prevent reformatting at every new page.
Fixes issue #401

Fix Foreign Policy
Block paywall-script which can also be blocked by uBlock Origin.

Add Philadelphia Inquirer
Already in Chrome extension.
Fixes issue #372