### PR TITLE
Fix Boston Globe (update)/WSJ (restrictions)/ET Prime/Spectator.co.uk/Quartz (gdpr) & add LeParisien.fr

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 [Investors Chronicle](https://www.investorschronicle.co.uk)\
 [La Repubblica](https://www.repubblica.it)\
 [Le Monde](https://www.lemonde.fr)\
+[Le Parisien](http://www.leparisien.fr)\
 [Le Temps](https://www.letemps.ch)\
 [London Review of Books](https://lrb.co.uk)\
 [Los Angeles Times](https://www.latimes.com)\

--- a/background.js
+++ b/background.js
@@ -188,7 +188,8 @@ const remove_cookies = [
 
 // select specific cookie(s) to hold from remove_cookies domains
 const remove_cookies_select_hold = {
-	'washingtonpost.com': ['wp_gdpr']
+	'washingtonpost.com': ['wp_gdpr'],
+	'qz.com': ['gdpr']
 }
 
 // select only specific cookie(s) to drop from remove_cookies domains

--- a/background.js
+++ b/background.js
@@ -99,7 +99,8 @@ var defaultSites = {
 };
 
 const restrictions = {
-  'barrons.com': 'barrons.com/articles'
+  'barrons.com': 'barrons.com/articles',
+  'wsj.com': 'wsj.com/articles'
 }
 
 // Don't remove cookies before page load

--- a/background.js
+++ b/background.js
@@ -36,6 +36,7 @@ var defaultSites = {
   'Investors Chronicle': 'investorschronicle.co.uk',
   'La Repubblica': 'repubblica.it',
   'Le Monde': 'lemonde.fr',
+  'Le Parisien': 'leparisien.fr',
   'Le Temps': 'letemps.ch',
   'London Review of Books': 'lrb.co.uk',
   'Los Angeles Times': 'latimes.com',

--- a/background.js
+++ b/background.js
@@ -303,8 +303,13 @@ browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
   
   // check for blocked regular expression: domain enabled, match regex, block on an internal or external regex
   for (var domain in blockedRegexes) {
-	  if (isSiteEnabled({url: '.'+ domain}) && details.url.match(blockedRegexes[domain])) {
+	  if ((isSiteEnabled({url: '.'+ domain}) || isSiteEnabled({url: header_referer})) && details.url.match(blockedRegexes[domain])) {
 			if (details.url.indexOf(domain) !== -1 || header_referer.indexOf(domain) !== -1) {
+				// allow BG paywall-script to set cookies in homepage/sections (else no article-text)
+				if (details.url.indexOf('meter.bostonglobe.com/js/') !== -1 && (header_referer === 'https://www.bostonglobe.com/' 
+						|| header_referer.indexOf('/?p1=BGHeader_') !== -1  || header_referer.indexOf('/?p1=BGMenu_') !== -1)) {
+					break;
+				}
 				return { cancel: true };
 			}
 	  }

--- a/background.js
+++ b/background.js
@@ -237,7 +237,8 @@ const blockedRegexes = {
 'lrb.co.uk': /.+\.tinypass\.com\/.+/,
 'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/,
 'foreignpolicy.com': /.+\.tinypass\.com\/.+/,
-'inquirer.com': /.+\.tinypass\.com\/.+/
+'inquirer.com': /.+\.tinypass\.com\/.+/,
+'spectator.co.uk': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"

--- a/background.js
+++ b/background.js
@@ -446,7 +446,7 @@ browser.webRequest.onCompleted.addListener(function(details) {
 
 function isSiteEnabled(details) {
   var isEnabled = enabledSites.some(function(enabledSite) {
-    var useSite = details.url.indexOf("." + enabledSite) !== -1;
+    var useSite = (details.url.indexOf("." + enabledSite) !== -1 || details.url.indexOf("/" + enabledSite) !== -1);
     if (enabledSite in restrictions) {
       return useSite && details.url.indexOf(restrictions[enabledSite]) !== -1;
     }

--- a/contentScript.js
+++ b/contentScript.js
@@ -6,6 +6,7 @@ var localstorage_hold = arr_localstorage_hold.some(function(url) {
 if (!localstorage_hold){
     window.localStorage.clear();
 }
+
 if (window.location.href.indexOf("bizjournals.com") !== -1) {
     const hiddenStory = document.getElementsByClassName(
         "js-pre-chunks__story-body"
@@ -194,6 +195,18 @@ if (window.location.href.indexOf("economist.com") !== -1) {
 if (window.location.href.indexOf("the-tls.co.uk") !== -1) {
         const paywall = document.querySelector('.tls-subscriptions-banner__closed-skin');
         removeDOMElement(paywall);
+}
+
+if (window.location.href.indexOf("leparisien.fr") !== -1) {
+        window.removeEventListener('scroll', this.scrollListener);
+        const paywall = document.querySelector('.relative.piano-paywall.below_nav.sticky');
+        removeDOMElement(paywall);
+        setTimeout(function () {
+            var content = document.getElementsByClassName('content');
+            for (var i = 0; i < content.length; i++) {
+                content[i].removeAttribute("style");
+            }
+        }, 300); // Delay (in milliseconds)
 }
 
 function removeDOMElement(...elements) {

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "*://*.volkskrant.nl/*",
     "*://*.washingtonpost.com/*",
     "*://*.economist.com/*",
-    "*://*.the-tls.co.uk/*"
+    "*://*.the-tls.co.uk/*",
+    "*://*.leparisien.fr/*"
       ],
       "js": ["contentScript.js"]
     }
@@ -154,7 +155,8 @@
     "*://*.harpers.org/*",
     "*://*.nknews.org/*",
     "*://*.inquirer.com/*",
-    "*://*.indiatimes.com/*"
+    "*://*.indiatimes.com/*",
+    "*://*.leparisien.fr/*"
   ],
   "version": "1.6.2"
 }

--- a/options.js
+++ b/options.js
@@ -34,6 +34,7 @@ var defaultSites = {
   'Investors Chronicle': 'investorschronicle.co.uk',
   'La Repubblica': 'repubblica.it',
   'Le Monde': 'lemonde.fr',
+  'Le Parisien': 'leparisien.fr',
   'Le Temps': 'letemps.ch',
   'London Review of Books': 'lrb.co.uk',
   'Los Angeles Times': 'latimes.com',


### PR DESCRIPTION
Update fix Boston Globe
Only enable Boston Globe paywall-script to set cookies at homepage/sections (no text in articles while no cookies).

Option to block scripts while site restrictions (effects isSiteEnabled).

WSJ restrictions (only active on articles).
Like Barron's.

Fix ET Prime
Update of function isSiteEnabled because no match with https://prime.economictimes.indiatimes.com (without dot-prefix).
Dot was added to prevent site.com to match with prefixsite.com.
Result: Googlebot wasn't set as user-agent.
Fixes request #406/PR #408

Fix Spectator.co.uk (without uBlock Origin)
Block paywall-script.
uBlock Origin (Fanboy’s Enhanced Tracking List) can also block this: ||tinypass.com^$3p

Fix Quartz/qz.com (gdpr)
Removal of gdpr-cookie kept refreshing the page.
PS adblocker needs to block xhr-element: ||vent.qz.com/log$xhr,1p
PS2 isSiteEnabled was updated earlier because no match with qz.com (without prefix www.).

Add LeParisien.fr
Already in Chrome extension.