### PR TITLE
add globes.co.il

### DIFF
--- a/background.js
+++ b/background.js
@@ -64,6 +64,7 @@ const remove_cookies = [
 'ed.nl',
 'examiner.com.au',
 'ft.com',
+'globes.co.il',
 'hacked.com',
 'harpers.org',
 'hbr.org',

--- a/common.js
+++ b/common.js
@@ -25,6 +25,7 @@ const defaultSites = {
     'Foreign Policy': 'foreignpolicy.com',
     'Fortune': 'fortune.com',
     'Glassdoor': 'glassdoor.com',
+    'Globes': 'globes.co.il',
     'Haaretz': 'haaretz.co.il',
     'Haaretz English': 'haaretz.com',
     'Handelsblatt': 'handelsblatt.com',

--- a/manifest.json
+++ b/manifest.json
@@ -87,6 +87,7 @@
     "*://*.foreignpolicy.com/*",
     "*://*.fortune.com/*",
     "*://*.glassdoor.com/*",
+    "*://*.globes.co.il/*",
     "*://*.haaretz.co.il/*",
     "*://*.haaretz.com/*",
     "*://*.handelsblatt.com/*",


### PR DESCRIPTION
This month [globes.co.il](https://www.globes.co.il/) added some soft paywall - user get 10 articles for free and than encounters a paywall.

Since 10 articles are free I can't give you a single page to see the paywall, just enter the website and browse some articles.

Removing cookies solves this issue.

As you asked in my last pull requests - I didn't increment the version or added anything in README.